### PR TITLE
feat(android): configure google maps api key for android

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,6 +37,11 @@
         "android.permission.FOREGROUND_SERVICE_LOCATION"
       ],
       "package": "com.sergii.carx",
+      "config": {
+        "googleMaps": {
+          "apiKey": "AIzaSyAeg73Geu1Tire1H5jwvkvx9tNNvQ-dOAk"
+        }
+      },
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/favicon.png",
         "backgroundColor": "#808080"


### PR DESCRIPTION
## Description
This PR resolves the `java.lang.IllegalStateException: API key not found` crash on Android by correctly configuring the Google Maps SDK in `app.json`.

## Changes
*   Added `googleMaps.apiKey` to the `android.config` section in `app.json`.
*   Configured Google Cloud Console API restrictions for Android:
    *   Added local development SHA-1 fingerprint.
    *   Added EAS Build (cloud) SHA-1 fingerprint to ensure production stability.

## Testing
*   Verified that the maps component initializes correctly on the local Android emulator.
*   The configuration is set up to support both local development and EAS Build environments securely.